### PR TITLE
FIX: Segfault due to invalid index from find_reference

### DIFF
--- a/unravel/find_reference.py
+++ b/unravel/find_reference.py
@@ -162,7 +162,7 @@ def find_reference_radials(azi, vel, debug=False):
 
     # Finding the 2nd radial of reference
     pos2 = pos1 + len(azi) // 2
-    if pos2 > len(azi):
+    if pos2 >= len(azi):
         pos2 -= len(azi)
 
 #     try:


### PR DESCRIPTION
This fixes a segfault caused by find_reference_radials returning 360 instead of 0 for an azimuth index.