### PR TITLE
Activate numba cache

### DIFF
--- a/unravel/continuity.py
+++ b/unravel/continuity.py
@@ -1007,7 +1007,7 @@ def _box_check_v2(refvel, final_vel, flag_vel, vnyq, alpha):
     return final_vel, flag_vel
 
 
-jit_module(nopython=True, error_model="numpy")
+jit_module(nopython=True, error_model="numpy", cache=True)
 
 
 def box_check(final_vel, flag_vel, vnyq, window_range=80, window_azimuth=40, alpha=0.8):

--- a/unravel/filtering.py
+++ b/unravel/filtering.py
@@ -43,7 +43,7 @@ def do_gatefilter(radar, dbz_name: str):
     return gf_desp
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def unfold(v: float, vref: float, vnq: float, vshift: float) -> float:
     """
     Unfold velocity.
@@ -73,7 +73,7 @@ def unfold(v: float, vref: float, vnq: float, vshift: float) -> float:
     return unfld
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def filter_data(velocity, vflag, vnyquist, vshift, delta_vmax, nfilter=10):
     """
     Filter data (despeckling) using MAD and first quick attempt at unfolding 

--- a/unravel/initialisation.py
+++ b/unravel/initialisation.py
@@ -251,4 +251,4 @@ def initialize_unfolding(azi_start_pos, azi_end_pos, vel, flag_vel, vnyq=13.3):
 
     return final_vel, flag_vel
 
-jit_module(nopython=True, error_model="numpy")
+jit_module(nopython=True, error_model="numpy", cache=True)


### PR DESCRIPTION
This PR update adds `cache=True` to the `@jit` and `@jit_module` decorators. This avoid the jit compilation every time the module is imported. See `https://numba.pydata.org/numba-doc/latest/user/jit.html#cache` for more details. 

This PR closes #12.